### PR TITLE
Implement advanced audio localization with GCC-PHAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project is developed by Craig Merry, who, being Deaf, is driven by the pers
 
 *   **On-Device AI:** All processing is done locally using the Gemma 3n `.task` model, ensuring privacy and low latency.
 *   **Multimodal Input:** The system is designed to fuse audio and visual data, providing context-aware transcriptions.
-*   **Spatial Audio Localization:** Utilizes stereo audio analysis to determine the direction of sound sources, placing captions spatially in the UI. A new `SpeechLocalizer` service provides real-time left/right angle estimates using RMS amplitude comparison.
+*   **Spatial Audio Localization:** Utilizes stereo audio analysis to determine the direction of sound sources, placing captions spatially in the UI. The `SpeechLocalizer` service now uses a GCC-PHAT time-delay algorithm for precise angle estimation.
 *   **Stereo Audio Capture:** New `StereoAudioCapture` service provides low-latency PCM buffers from the device microphones.
 *   **Cross-Platform:** Built with Flutter, targeting Android (including XR) and iOS.
 *   **High-Performance:** Leverages Google's MediaPipe Tasks for optimized, hardware-accelerated inference.

--- a/docs/ARCHITECTURE_RESEARCH.md
+++ b/docs/ARCHITECTURE_RESEARCH.md
@@ -825,6 +825,10 @@ Here’s how to break down the previous comprehensive solution into smaller, man
 * **Deliverable:** Accurate angle and direction estimation method within the inference package.
 * **Outcome:** High-precision localization suitable for AR anchoring.
 
+* **Implementation Update:** This task is now implemented using a GCC-PHAT
+  algorithm in the Dart `SpeechLocalizer` service to calculate time-delay
+  between stereo channels for precise angle estimation.
+
 ---
 
 ## 🎯 **Task 4: Integration of Gemma 3n for Streaming On-Device ASR**

--- a/docs/ON_DEVICE_SPEECH_LOCALIZATION_IOS.md
+++ b/docs/ON_DEVICE_SPEECH_LOCALIZATION_IOS.md
@@ -31,7 +31,7 @@ class LocalizationAndCaptioningEngine {
     // Called when a new audio buffer is available from AVAudioEngine
     func processAudioBuffer(_ buffer: AVAudioPCMBuffer) {
         // 1. Estimate direction from the stereo buffer
-        let angle = estimateDirection(from: buffer) // Basic RMS left/right
+        let angle = estimateDirectionAdvanced(from: buffer) // GCC-PHAT TDOA
         
         // 2. Get transcription from Gemma 3n via MediaPipe
         let monoBuffer = downmixToMono(buffer: buffer)

--- a/lib/core/services/audio_service.dart
+++ b/lib/core/services/audio_service.dart
@@ -66,7 +66,7 @@ class AudioService {
 
     await _audioCapture.startRecording();
     _captureSub = _audioCapture.frames.listen((frame) {
-      final angle = _speechLocalizer.estimateDirection(frame);
+      final angle = _speechLocalizer.estimateDirectionAdvanced(frame);
       _processAudioFrame(frame.toMono(), angle);
     });
 

--- a/prd/03_advanced_audio_localization.md
+++ b/prd/03_advanced_audio_localization.md
@@ -110,3 +110,15 @@
 | [Name]            | Engineering Lead    |               |
 
 ---
+
+## Repository Updates
+
+The following commits implement Task 3:
+
+* Added the **scidart** dependency for FFT-based signal processing.
+* Implemented `estimateDirectionAdvanced` in `SpeechLocalizer` using the
+  GCC-PHAT algorithm for precise TDOA calculation.
+* Updated `AudioService` to use the new advanced localization method.
+* Revised README and technical docs to reflect the GCC-PHAT pipeline.
+
+---

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -224,6 +224,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
+  scidart:
+    dependency: "direct main"
+    description:
+      name: scidart
+      sha256: af816eed552cadb6a9a324c594515b0cdff41617839345c382047927bd8dc02d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2-dev.12"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   go_router: ^15.2.4
   get_it: ^8.0.3
   tflite_flutter: ^0.11.0
+  scidart: ^0.0.2-dev.12
   # Add your other dependencies here
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add `scidart` dependency for FFT signal processing
- implement `estimateDirectionAdvanced` using GCC-PHAT
- use advanced localization in AudioService
- document new pipeline in README and docs
- update PRD 03 with repository updates

## Testing
- `flutter pub get`
- `dart format lib/core/services/speech_localizer.dart lib/core/services/audio_service.dart`
- `flutter test`
- `flutter analyze` *(fails: 136 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68620375aa38832ca03d155fb085f4e2