### PR TITLE
Add plugin PRD for Android model loading

### DIFF
--- a/plugins/gemma3n_multimodal/README.md
+++ b/plugins/gemma3n_multimodal/README.md
@@ -17,7 +17,7 @@ samples, guidance on mobile development, and a full API reference.
 
 | Feature                        | PRD File                                 | Status    |
 |--------------------------------|------------------------------------------|-----------|
-| Android Model Loading          | prd/01_android_model_loading.md           | Planned   |
+| Android Model Loading          | prd/01_android_model_loading.md           | Draft     |
 | iOS Model Loading              | prd/02_ios_model_loading.md               | Planned   |
 | Dart API & MethodChannel       | prd/03_dart_api_and_method_channel.md     | Planned   |
 | Streaming Inference            | prd/04_streaming_inference.md             | Planned   |

--- a/plugins/gemma3n_multimodal/prd/01_android_model_loading.md
+++ b/plugins/gemma3n_multimodal/prd/01_android_model_loading.md
@@ -1,33 +1,41 @@
 # PRD: Android Model Loading for gemma3n_multimodal Plugin
 
 ## Overview
-Implement native model loading for the Gemma 3n .task file on Android using MediaPipe Tasks/GenAI or Google AI Edge SDK. This is the foundation for all inference features in the plugin.
+In **LiveCaptionsXR**, all captioning runs directly on device using Google's Gemma 3n `.task` model. This document defines how the Android side of the `gemma3n_multimodal` plugin loads that model so the app can deliver the real-time, spatial captions described in the project's [README](../../README.md).
 
 ## Goals
-- Load the Gemma 3n .task model from app assets or device storage.
-- Support hardware acceleration (GPU/CPU fallback).
-- Expose a Dart API to trigger model loading and report success/failure.
+- Provide a Kotlin implementation that loads the Gemma 3n `.task` file from assets or external storage.
+- Support GPU acceleration when available with CPU/NNAPI fallback.
+- Expose a simple Dart API so the Flutter layer knows when the model is ready.
+- Keep initialization time low to maintain the app's fast startup.
 
 ## Requirements
-- Use MediaPipe's `LlmInference.createFromOptions` with the model path.
-- Copy the .task file from assets to a writable location if needed.
-- Handle errors (file not found, insufficient memory, etc.) gracefully.
-- Log model loading time and backend used.
+- Copy the `.task` file from assets to a writable directory on first launch if direct asset access is not permitted.
+- Use `LlmInference.createFromOptions` (MediaPipe/Google AI Edge) to initialize the model with hardware acceleration flags.
+- Validate the file path and available memory before loading.
+- Emit descriptive errors for missing files or unsupported hardware.
+- Log the model path, selected backend and load time for troubleshooting.
+- Provide a method to unload the model when the plugin is disposed.
 
 ## Dart API
 ```dart
-Future<void> loadModel(String path, {bool useGPU});
+Future<void> loadModel(String path, {bool useGPU = false});
+Future<void> unloadModel();
+bool get isModelLoaded;
 ```
-- Returns when the model is loaded and ready for inference.
-- Throws on error (with descriptive message).
+- `loadModel` resolves when native loading completes or throws on error.
+- `unloadModel` frees native resources.
+- `isModelLoaded` allows the app to guard calls that require the model.
 
 ## Milestones
-- [ ] Copy .task file from assets to device storage
-- [ ] Implement native model loading in Kotlin
-- [ ] Expose MethodChannel for Dart API
-- [ ] Error handling and logging
-- [ ] Unit/integration tests
+- [ ] Asset copy and storage permission handling
+- [ ] Kotlin implementation using MediaPipe/Google AI Edge
+- [ ] MethodChannel interface for `loadModel` and `unloadModel`
+- [ ] Error propagation and logging
+- [ ] Basic unit tests for the loader
 
 ## References
 - [MediaPipe GenAI Android Docs](https://ai.google.dev/edge/mediapipe/solutions/genai/llm_inference/android)
-- [Flutter Plugin Platform Channels](https://docs.flutter.dev/platform-integration/platform-channels) 
+- [Flutter Plugin Platform Channels](https://docs.flutter.dev/platform-integration/platform-channels)
+- [LiveCaptionsXR README](../../README.md)
+


### PR DESCRIPTION
## Summary
- flesh out gemma3n_multimodal Android model loading PRD with goals and API
- mark Android PRD as `Draft` in plugin README

## Testing
- `flutter analyze` *(fails: 148 issues)*
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68633403af24832cb903003257b0ec50