### PR TITLE
Rewrite iOS model loading PRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project is developed by Craig Merry, who, being Deaf, is driven by the pers
 
 ## ✨ Core Features
 
-*   **On-Device AI:** All processing is done locally using the Gemma 3n `.task` model, ensuring privacy and low latency.
+*   **On-Device AI:** All processing is done locally using the Gemma 3n `.task` model, ensuring privacy and low latency. Model initialization now leverages the community [`flutter_gemma`](https://pub.dev/packages/flutter_gemma) plugin for optimized loading on iOS and Android.
 *   **Multimodal Fusion:** The app combines audio and visual data for more accurate and context-aware transcriptions.
 *   **Visual Speaker Identification:** The app uses the Vision framework on iOS and ML Kit on Android to detect faces and identify the active speaker.
 *   **ARKit Anchor Creation:** The app can create and manage ARKit anchors to place captions in the 3D world.

--- a/plugins/gemma3n_multimodal/README.md
+++ b/plugins/gemma3n_multimodal/README.md
@@ -18,7 +18,7 @@ samples, guidance on mobile development, and a full API reference.
 | Feature                        | PRD File                                 | Status    |
 |--------------------------------|------------------------------------------|-----------|
 | Android Model Loading          | prd/01_android_model_loading.md           | Draft     |
-| iOS Model Loading              | prd/02_ios_model_loading.md               | Planned   |
+| iOS Model Loading              | prd/02_ios_model_loading.md               | In Progress |
 | Dart API & MethodChannel       | prd/03_dart_api_and_method_channel.md     | Planned   |
 | Streaming Inference            | prd/04_streaming_inference.md             | Planned   |
 | Multimodal Input Handling      | prd/05_multimodal_input.md                | Planned   |

--- a/plugins/gemma3n_multimodal/lib/gemma3n_multimodal.dart
+++ b/plugins/gemma3n_multimodal/lib/gemma3n_multimodal.dart
@@ -1,7 +1,40 @@
-
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma/pigeon.g.dart';
+import 'package:flutter_gemma/core/model.dart';
 import 'gemma3n_multimodal_platform_interface.dart';
 
+/// Wrapper around [FlutterGemmaPlugin] providing helpers for
+/// the LiveCaptionsXR application.
 class Gemma3nMultimodal {
+  Gemma3nMultimodal({FlutterGemmaPlugin? gemma})
+      : _gemma = gemma ?? FlutterGemmaPlugin.instance;
+
+  final FlutterGemmaPlugin _gemma;
+
+  /// Loads a Gemma model from [path] using [flutter_gemma].
+  ///
+  /// When [useANE] is true, the plugin attempts to use Apple's
+  /// Neural Engine (mapped to [PreferredBackend.tpu]). If false,
+  /// [useGPU] may request a GPU backend; otherwise the CPU is used.
+  Future<void> loadModel(
+    String path, {
+    bool useANE = true,
+    bool useGPU = false,
+  }) async {
+    await _gemma.modelManager.setModelPath(path);
+    final backend = useANE
+        ? PreferredBackend.tpu
+        : useGPU
+            ? PreferredBackend.gpu
+            : PreferredBackend.cpu;
+    await _gemma.createModel(
+      modelType: ModelType.general,
+      preferredBackend: backend,
+      supportImage: true,
+      maxNumImages: 1,
+    );
+  }
+
   Future<String?> getPlatformVersion() {
     return Gemma3nMultimodalPlatform.instance.getPlatformVersion();
   }

--- a/plugins/gemma3n_multimodal/prd/02_ios_model_loading.md
+++ b/plugins/gemma3n_multimodal/prd/02_ios_model_loading.md
@@ -1,33 +1,41 @@
 # PRD: iOS Model Loading for gemma3n_multimodal Plugin
 
 ## Overview
-Implement native model loading for the Gemma 3n .task file on iOS using MediaPipe Tasks/GenAI or Google AI Edge SDK. This is the foundation for all inference features in the plugin on iOS.
+The `gemma3n_multimodal` plugin provides on-device inference using Google's Gemma 3n model. This PRD describes how the model is loaded on iOS devices. Loading is performed via the `flutter_gemma` package, which wraps MediaPipe Tasks and provides a high level Dart API for model initialization.
 
 ## Goals
-- Load the Gemma 3n .task model from app bundle or device storage.
-- Support hardware acceleration (ANE/GPU/CPU fallback).
-- Expose a Dart API to trigger model loading and report success/failure.
+- Copy the `.task` model from the application bundle to a writable location on first launch.
+- Initialize the model using `flutter_gemma` with hardware acceleration when available (ANE > GPU > CPU).
+- Provide a Dart method `loadModel` returning a `Future<void>` that completes when initialization succeeds.
+- Emit detailed errors when the model cannot be loaded.
+- Record load time and chosen backend for debugging.
 
 ## Requirements
-- Use MediaPipe's or Google AI Edge's iOS API to load the model from a file path.
-- Copy the .task file from the app bundle to a writable location if needed.
-- Handle errors (file not found, insufficient memory, etc.) gracefully.
-- Log model loading time and backend used.
+- Rely on `flutter_gemma` for the underlying model manager and initialization APIs.
+- Support specifying the backend preference through the Dart API (`useANE`, `useGPU`).
+- Verify file existence and available memory before loading.
+- Log results via `print` statements during development; integrate with app logging later.
+- Unit tests must mock `FlutterGemmaPlugin` to ensure correct method calls.
 
 ## Dart API
 ```dart
-Future<void> loadModel(String path, {bool useANE, bool useGPU});
+Future<void> loadModel(
+  String path, {
+  bool useANE = true,
+  bool useGPU = false,
+});
 ```
-- Returns when the model is loaded and ready for inference.
-- Throws on error (with descriptive message).
+- `useANE` maps to `PreferredBackend.tpu` on iOS.
+- When both flags are false the CPU backend is used.
+- Throws an exception if initialization fails.
 
 ## Milestones
-- [ ] Copy .task file from bundle to device storage
-- [ ] Implement native model loading in Swift/ObjC
-- [ ] Expose MethodChannel for Dart API
-- [ ] Error handling and logging
-- [ ] Unit/integration tests
+- [ ] Bundle copy utility written in Swift.
+- [ ] Swift implementation calling `FlutterGemmaPlugin`.
+- [ ] Dart wrapper with injectable `FlutterGemmaPlugin` for testing.
+- [ ] Unit tests verifying path copy and plugin calls.
 
 ## References
 - [MediaPipe GenAI iOS Docs](https://ai.google.dev/edge/mediapipe/solutions/genai/llm_inference/ios)
-- [Flutter Plugin Platform Channels](https://docs.flutter.dev/platform-integration/platform-channels) 
+- [flutter_gemma package](https://pub.dev/packages/flutter_gemma)
+- [Flutter Plugin Platform Channels](https://docs.flutter.dev/platform-integration/platform-channels)

--- a/plugins/gemma3n_multimodal/pubspec.yaml
+++ b/plugins/gemma3n_multimodal/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
+  flutter_gemma: ^0.9.0
 
 dev_dependencies:
   flutter_test:

--- a/plugins/gemma3n_multimodal/test/gemma3n_multimodal_test.dart
+++ b/plugins/gemma3n_multimodal/test/gemma3n_multimodal_test.dart
@@ -3,6 +3,11 @@ import 'package:gemma3n_multimodal/gemma3n_multimodal.dart';
 import 'package:gemma3n_multimodal/gemma3n_multimodal_platform_interface.dart';
 import 'package:gemma3n_multimodal/gemma3n_multimodal_method_channel.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma/pigeon.g.dart';
+import 'package:flutter_gemma/core/model.dart';
+import 'package:flutter_gemma/core/message.dart';
+import 'package:flutter_gemma/core/chat.dart';
 
 class MockGemma3nMultimodalPlatform
     with MockPlatformInterfaceMixin
@@ -10,6 +15,142 @@ class MockGemma3nMultimodalPlatform
 
   @override
   Future<String?> getPlatformVersion() => Future.value('42');
+}
+
+class FakeModelManager implements ModelFileManager {
+  int setPathCalls = 0;
+  String? lastPath;
+
+  @override
+  Future<bool> get isModelInstalled async => true;
+
+  @override
+  Future<bool> get isLoraInstalled async => false;
+
+  @override
+  Future<void> setModelPath(String path, {String? loraPath}) async {
+    setPathCalls++;
+    lastPath = path;
+  }
+
+  // The remaining methods are no-ops for testing.
+  @override
+  Future<void> setLoraWeightsPath(String path) async {}
+
+  @override
+  Future<void> downloadModelFromNetwork(String url, {String? loraUrl}) async {}
+
+  @override
+  Stream<int> downloadModelFromNetworkWithProgress(String url,
+          {String? loraUrl}) async* {}
+
+  @override
+  Future<void> downloadLoraWeightsFromNetwork(String loraUrl) async {}
+
+  @override
+  Future<void> installModelFromAsset(String path, {String? loraPath}) async {}
+
+  @override
+  Future<void> installLoraWeightsFromAsset(String path) async {}
+
+  @override
+  Stream<int> installModelFromAssetWithProgress(String path,
+          {String? loraPath}) async* {}
+
+  @override
+  Future<void> deleteModel() async {}
+
+  @override
+  Future<void> deleteLoraWeights() async {}
+}
+
+class FakeFlutterGemma extends FlutterGemmaPlugin
+    with MockPlatformInterfaceMixin {
+  FakeFlutterGemma();
+
+  final FakeModelManager manager = FakeModelManager();
+  int createModelCalls = 0;
+
+  @override
+  ModelFileManager get modelManager => manager;
+
+  @override
+  InferenceModel? get initializedModel => null;
+
+  @override
+  Future<InferenceModel> createModel({
+    required ModelType modelType,
+    int maxTokens = 1024,
+    PreferredBackend? preferredBackend,
+    List<int>? loraRanks,
+    int? maxNumImages,
+    bool supportImage = false,
+  }) async {
+    createModelCalls++;
+    return DummyInferenceModel();
+  }
+
+  @override
+  Future<void> close() async {}
+}
+
+class DummyInferenceModel implements InferenceModel {
+  @override
+  InferenceModelSession? get session => null;
+
+  @override
+  InferenceChat? chat;
+
+  @override
+  int get maxTokens => 0;
+
+  @override
+  Future<InferenceModelSession> createSession({
+    double temperature = .8,
+    int randomSeed = 1,
+    int topK = 1,
+    double? topP,
+    String? loraPath,
+    bool? enableVisionModality,
+  }) async {
+    return DummyInferenceSession();
+  }
+
+  @override
+  Future<InferenceChat> createChat({
+    double temperature = .8,
+    int randomSeed = 1,
+    int topK = 1,
+    double? topP,
+    int tokenBuffer = 256,
+    String? loraPath,
+    bool? supportImage,
+  }) async {
+    return InferenceChat(
+      sessionCreator: () async => DummyInferenceSession(),
+      maxTokens: 0,
+    );
+  }
+
+  @override
+  Future<void> close() async {}
+}
+
+class DummyInferenceSession implements InferenceModelSession {
+  @override
+  Future<void> addQueryChunk(Message message) async {}
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  Future<String> getResponse() async => '';
+
+  @override
+  Stream<String> getResponseAsync() async* {}
+
+  @override
+  Future<int> sizeInTokens(String text) async => 0;
 }
 
 void main() {
@@ -25,5 +166,16 @@ void main() {
     Gemma3nMultimodalPlatform.instance = fakePlatform;
 
     expect(await gemma3nMultimodalPlugin.getPlatformVersion(), '42');
+  });
+
+  test('loadModel uses flutter_gemma', () async {
+    final fakeGemma = FakeFlutterGemma();
+    final plugin = Gemma3nMultimodal(gemma: fakeGemma);
+
+    await plugin.loadModel('path/to/model.task', useANE: false, useGPU: true);
+
+    expect(fakeGemma.manager.setPathCalls, 1);
+    expect(fakeGemma.manager.lastPath, 'path/to/model.task');
+    expect(fakeGemma.createModelCalls, 1);
   });
 }


### PR DESCRIPTION
## Summary
- rewrite the iOS model loading PRD with flutter_gemma integration
- update plugin README table
- reference flutter_gemma loading in root README
- add flutter_gemma dependency and basic loadModel helper
- add unit test for loadModel

## Testing
- `flutter test` (root)
- `flutter test` (plugins/gemma3n_multimodal)

------
https://chatgpt.com/codex/tasks/task_e_68634470111c832ca67c3aadff17f254