### PR TITLE
Fix iOS Pod configuration

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -29,6 +29,7 @@ flutter_ios_podfile_setup
 
 target 'Runner' do
   use_frameworks! :linkage => :static
+  use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do

--- a/plugins/gemma3n_multimodal/ios/gemma3n_multimodal.podspec
+++ b/plugins/gemma3n_multimodal/ios/gemma3n_multimodal.podspec
@@ -15,6 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
+  s.static_framework = true
   s.dependency 'MediaPipeTasksGenAI'
   s.dependency 'MediaPipeTasksGenAIC'
   s.dependency 'MediaPipeTasksVision'


### PR DESCRIPTION
## Summary
- set `use_modular_headers!` to avoid MediaPipe config merge warnings
- build gemma3n_multimodal plugin as a static framework

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6865929cd984832c918caa3d1d2e00c7