### PR TITLE
Enable debug overlay on all builds

### DIFF
--- a/DEBUG_LOGGING.md
+++ b/DEBUG_LOGGING.md
@@ -1,6 +1,6 @@
-# Debug Logging Overlay for TestFlight
+# Debug Logging Overlay
 
-This feature provides a comprehensive debug logging system designed specifically for TestFlight builds, allowing developers to view real-time logs directly on the device without needing a debugger connection.
+This feature provides a comprehensive debug logging system that lets developers view real-time logs directly on the device without needing a debugger connection. The overlay can be enabled in any build variant.
 
 ## Features
 
@@ -18,7 +18,7 @@ This feature provides a comprehensive debug logging system designed specifically
 ### 1. Enable Debug Logging
 
 1. Open the app and go to **Settings**
-2. Scroll down to **Developer & Testing** (visible in debug, profile, and TestFlight builds)
+2. Scroll down to **Developer & Testing** (visible in all build variants)
 3. Look for the prominent **"Debug Logging Overlay"** card with bug report icon
 4. Toggle the switch to **ON** or tap anywhere on the card to enable
 5. You'll see a confirmation message and instructions appear below the toggle
@@ -76,18 +76,18 @@ lib/
 
 ## Security & Privacy
 
-- Only works in debug, profile, and TestFlight builds (`kDebugMode || kProfileMode || assertions enabled`)
+- Works in all build variants
 - Automatically clears logs when disabled
 - Logs are stored only in memory, not persisted to disk
 - Limited to 500 entries to prevent memory issues
 
-## TestFlight Usage
+## Why It's Useful
 
-This feature is particularly useful for TestFlight builds where:
-- Traditional debugging tools aren't available
-- You need to capture logs from real user devices
-- You want to troubleshoot issues reported by beta testers
-- You need to verify log output in production-like environments
+This overlay is helpful when traditional debugging tools aren't available because it lets you:
+- Capture logs from real user devices
+- Troubleshoot issues reported by testers
+- Verify log output in production-like environments
+
 
 ## Customization
 

--- a/docs/iOS_SIZE_OPTIMIZATION.md
+++ b/docs/iOS_SIZE_OPTIMIZATION.md
@@ -27,13 +27,7 @@ Enhanced the Podfile with size-specific optimizations:
 - Ensured proper stripping of symbols
 - Optimized MediaPipe framework linking
 
-### 3. App Thinning Configuration
-Created `ios/ExportOptions.plist` with:
-- App thinning for all variants
-- Symbol stripping enabled
-- Bitcode disabled (as required by MediaPipe)
-
-### 4. Build Script
+### 3. Build Script
 Created `scripts/build_ios_optimized.sh` with:
 - Tree shaking for icons
 - Code obfuscation
@@ -63,11 +57,11 @@ flutter build ios --release \
   --obfuscate
 ```
 
-### Option 3: Xcode Archive (Recommended for TestFlight)
+### Option 3: Xcode Archive
 1. Open `ios/Runner.xcworkspace` in Xcode
 2. Select "Any iOS Device" as target
 3. Product → Archive
-4. Export with `ios/ExportOptions.plist`
+4. Use Xcode's standard export options for distribution
 
 ## Additional Recommendations
 

--- a/iOS_BUILD_STATUS.md
+++ b/iOS_BUILD_STATUS.md
@@ -20,7 +20,6 @@ The app previously exceeded TestFlight's 4GB size limit. Now optimized with:
 - App thinning for all device variants  
 - Size-optimized compiler settings
 - Automated build script: `scripts/build_ios_optimized.sh`
-- Export configuration: `ios/ExportOptions.plist`
 
 **Result**: App size significantly reduced and TestFlight-ready ✅
 

--- a/lib/core/services/debug_capturing_logger.dart
+++ b/lib/core/services/debug_capturing_logger.dart
@@ -1,7 +1,7 @@
 import 'package:logger/logger.dart';
 import 'debug_logger_service.dart';
 
-/// A custom logger that captures logs to the debug logger service for TestFlight builds
+/// A custom logger that captures logs to the debug logger service
 class DebugCapturingLogger {
   final Logger _logger;
   final DebugLoggerService _debugService = DebugLoggerService();

--- a/lib/core/services/debug_logger_service.dart
+++ b/lib/core/services/debug_logger_service.dart
@@ -3,12 +3,12 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:logger/logger.dart';
 
-/// A service that captures and manages debug logs for TestFlight builds
+/// A service that captures and manages debug logs
 ///
 /// This service provides a centralized logging system that captures debug logs
 /// and displays them in a transparent overlay on the app screen. It's designed
-/// specifically for TestFlight builds where developers need to see real-time
-/// logs without connecting to a debugger.
+/// for viewing real-time logs directly on the device without connecting to a
+/// debugger.
 ///
 /// ## How to Use:
 ///
@@ -37,7 +37,7 @@ import 'package:logger/logger.dart';
 /// - Clear logs functionality
 /// - Privacy-aware (clears logs when disabled)
 /// - Memory efficient (limits to 500 entries)
-/// - Only works in debug/profile builds and TestFlight builds for security
+/// - Works in all build variants
 class DebugLoggerService {
   static final DebugLoggerService _instance = DebugLoggerService._internal();
   factory DebugLoggerService() => _instance;
@@ -61,15 +61,8 @@ class DebugLoggerService {
 
   /// Initialize the debug logger service
   void initialize() {
-    // Allow debug logging in debug, profile builds, and when assertions are enabled
-    // This covers TestFlight builds which typically have assertions enabled
-    bool isDevelopmentBuild = kDebugMode || kProfileMode;
-    bool assertionsEnabled = false;
-    assert(assertionsEnabled = true);
-    
-    if (isDevelopmentBuild || assertionsEnabled) {
-      _setupLogInterception();
-    }
+    // Always set up log interception so the overlay works in all build variants
+    _setupLogInterception();
   }
 
   /// Enable or disable debug logging

--- a/lib/features/settings/view/settings_screen.dart
+++ b/lib/features/settings/view/settings_screen.dart
@@ -9,13 +9,8 @@ class SettingsScreen extends StatelessWidget {
   /// Check if we're in a development or testing build
   /// This includes debug mode, profile mode, or when assertions are enabled
   bool get _isDevelopmentBuild {
-    bool isInDevelopmentMode = kDebugMode || kProfileMode;
-    
-    // Also check for assertions (which are enabled in debug and profile builds)
-    bool assertionsEnabled = false;
-    assert(assertionsEnabled = true);
-    
-    return isInDevelopmentMode || assertionsEnabled;
+    // The debug logging overlay is available in all build variants
+    return true;
   }
 
   @override
@@ -107,7 +102,7 @@ class SettingsScreen extends StatelessWidget {
 
               const SizedBox(height: 32),
 
-              // Developer Settings Section (show in development builds including TestFlight)
+              // Developer Settings Section
               if (_isDevelopmentBuild) ...[
                 _buildSectionHeader('Developer & Testing'),
                 const SizedBox(height: 16),
@@ -126,7 +121,7 @@ class SettingsScreen extends StatelessWidget {
                     ),
                     subtitle: const Text(
                       'Show transparent debug log overlay on screen\n'
-                      'Useful for TestFlight debugging and issue reporting',
+                      'Useful for debugging and issue reporting',
                     ),
                     trailing: Switch(
                       value: state.debugLoggingEnabled,
@@ -244,7 +239,7 @@ class SettingsScreen extends StatelessWidget {
                           const SizedBox(height: 8),
                           const Text(
                             'Turn on debug logging to see a transparent overlay with real-time app logs on the Home screen. '
-                            'This is especially useful for TestFlight testing and troubleshooting issues.',
+                            'This is especially useful for troubleshooting issues.',
                             style: TextStyle(fontSize: 12),
                           ),
                         ],

--- a/lib/shared/widgets/debug_logging_overlay.dart
+++ b/lib/shared/widgets/debug_logging_overlay.dart
@@ -282,7 +282,7 @@ class _DebugLoggingOverlayState extends State<DebugLoggingOverlay> {
             ),
           ),
           Text(
-            'TestFlight Debug Mode',
+            'Debug Overlay',
             style: const TextStyle(
               color: Colors.orange,
               fontSize: 10,

--- a/scripts/build_ios_optimized.sh
+++ b/scripts/build_ios_optimized.sh
@@ -35,11 +35,11 @@ flutter build ios --release \
   --obfuscate
 
 echo "✅ iOS build completed with size optimizations!"
-echo "📱 To create archive for TestFlight:"
+echo "📱 To create archive:"
 echo "   1. Open ios/Runner.xcworkspace in Xcode"
 echo "   2. Select 'Any iOS Device' as target"
 echo "   3. Product -> Archive"
-echo "   4. Use the ExportOptions.plist for app store distribution"
+echo "   4. Xcode's standard export options for distribution"
 
 # Display approximate build size
 if [ -d "build/ios/iphoneos/Runner.app" ]; then


### PR DESCRIPTION
## Summary
- always return `true` for `_isDevelopmentBuild`
- initialize debug logger service in every build
- rename overlay label and docs to drop TestFlight requirement
- remove `ExportOptions.plist` usage in docs and build script
- tweak settings screen text

## Testing
- `flutter test` *(fails: unable to find directory entry in pubspec.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_686754736918832c9694ab248d35b4a7