### PR TITLE
Improve camera fallback and Whisper queue handling

### DIFF
--- a/lib/core/services/camera_service.dart
+++ b/lib/core/services/camera_service.dart
@@ -6,23 +6,30 @@ import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 /// Camera service for visual processing and capture
-/// 
+///
 /// This service handles camera initialization, frame capture, and integration
 /// with visual processing services for the LiveCaptionsXR application.
 class CameraService {
   static final AppLogger _logger = AppLogger.instance;
-  
+
   bool _isCameraStarted = false;
   bool _isInitialized = false;
   Completer<void>? _initializeCompleter;
 
   CameraController? _cameraController;
   List<CameraDescription>? _cameras;
-  
+
   Timer? _periodicCaptureTimer;
-  final StreamController<List<int>> _frameStreamController = StreamController<List<int>>.broadcast();
+  final StreamController<List<int>> _frameStreamController =
+      StreamController<List<int>>.broadcast();
   bool _isCaptureInProgress = false;
-  
+
+  static const List<ResolutionPreset> _resolutionFallbacks = <ResolutionPreset>[
+    ResolutionPreset.medium,
+    ResolutionPreset.low,
+  ];
+  int _resolutionIndex = 0;
+
   /// Initialize the camera service for mobile platforms
   Future<void> initialize() async {
     if (_initializeCompleter != null) {
@@ -35,66 +42,104 @@ class CameraService {
 
     final completer = Completer<void>();
     _initializeCompleter = completer;
-    _logger.i('🏗️ Initializing CameraService...', category: LogCategory.camera);
+    _logger.i(
+      '🏗️ Initializing CameraService...',
+      category: LogCategory.camera,
+    );
     try {
-      _logger.d('Setting up camera configuration...', category: LogCategory.camera);
+      _logger.d(
+        'Setting up camera configuration...',
+        category: LogCategory.camera,
+      );
       // Initialize camera for mobile platforms (Android and iOS)
-      if (!kIsWeb && (defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS)) {
-        _logger.d('Checking available cameras...', category: LogCategory.camera);
+      if (!kIsWeb &&
+          (defaultTargetPlatform == TargetPlatform.android ||
+              defaultTargetPlatform == TargetPlatform.iOS)) {
+        _logger.d(
+          'Checking available cameras...',
+          category: LogCategory.camera,
+        );
         await _ensureCameraPermission();
         _cameras = await availableCameras();
         final frontCamera = _cameras!.firstWhere(
           (c) => c.lensDirection == CameraLensDirection.front,
           orElse: () => _cameras!.first,
         );
-        _cameraController = CameraController(frontCamera, ResolutionPreset.medium);
-        await _cameraController!.initialize();
+        await _initializeCameraController(frontCamera);
         _isInitialized = true;
-        _logger.i('✅ CameraService initialized successfully', category: LogCategory.camera);
+        _logger.i(
+          '✅ CameraService initialized successfully',
+          category: LogCategory.camera,
+        );
       } else {
-        _logger.i('ℹ️ CameraService skipped (web platform detected)', category: LogCategory.camera);
+        _logger.i(
+          'ℹ️ CameraService skipped (web platform detected)',
+          category: LogCategory.camera,
+        );
         _isInitialized = false;
       }
       completer.complete();
     } catch (e, stackTrace) {
-      _logger.e('❌ Camera initialization failed', category: LogCategory.camera, error: e, stackTrace: stackTrace);
+      _logger.e(
+        '❌ Camera initialization failed',
+        category: LogCategory.camera,
+        error: e,
+        stackTrace: stackTrace,
+      );
       completer.completeError(e, stackTrace);
       rethrow;
     } finally {
       _initializeCompleter = null;
     }
   }
-  
+
   /// Start camera capture
   void startCamera() {
     _logger.i('📸 Starting camera...', category: LogCategory.camera);
-    _logger.d('Current state - Initialized: $_isInitialized, Started: $_isCameraStarted', category: LogCategory.camera);
-    
+    _logger.d(
+      'Current state - Initialized: $_isInitialized, Started: $_isCameraStarted',
+      category: LogCategory.camera,
+    );
+
     if (!_isInitialized) {
-      _logger.e('❌ Camera not initialized, cannot start', category: LogCategory.camera);
-      throw StateError('Camera service not initialized. Call initialize() first.');
+      _logger.e(
+        '❌ Camera not initialized, cannot start',
+        category: LogCategory.camera,
+      );
+      throw StateError(
+        'Camera service not initialized. Call initialize() first.',
+      );
     }
-    
+
     if (_isCameraStarted) {
-      _logger.w('⚠️ Camera already started, skipping start', category: LogCategory.camera);
+      _logger.w(
+        '⚠️ Camera already started, skipping start',
+        category: LogCategory.camera,
+      );
       return;
     }
-    
+
     _isCameraStarted = true;
     _startPeriodicCapture();
     _logger.i('✅ Camera started successfully', category: LogCategory.camera);
   }
-  
+
   /// Stop camera capture
   void stopCamera() {
     _logger.i('📸 Stopping camera...', category: LogCategory.camera);
-    _logger.d('Current state - Started: $_isCameraStarted', category: LogCategory.camera);
-    
+    _logger.d(
+      'Current state - Started: $_isCameraStarted',
+      category: LogCategory.camera,
+    );
+
     if (!_isCameraStarted) {
-      _logger.w('⚠️ Camera not started, nothing to stop', category: LogCategory.camera);
+      _logger.w(
+        '⚠️ Camera not started, nothing to stop',
+        category: LogCategory.camera,
+      );
       return;
     }
-    
+
     _stopPeriodicCapture();
     _isCameraStarted = false;
     _logger.i('✅ Camera stopped successfully', category: LogCategory.camera);
@@ -107,91 +152,270 @@ class CameraService {
     }
     return null;
   }
-  
+
   /// Capture a single frame from the camera
   Future<List<int>?> captureFrame() async {
     _logger.d('📷 Capturing camera frame...', category: LogCategory.camera);
-    
+
     if (!_isCameraStarted || _cameraController == null) {
-      _logger.w('⚠️ Camera not started or controller unavailable, cannot capture frame', category: LogCategory.camera);
+      _logger.w(
+        '⚠️ Camera not started or controller unavailable, cannot capture frame',
+        category: LogCategory.camera,
+      );
       return null;
     }
-    
+
     if (!_cameraController!.value.isInitialized) {
-      _logger.w('⚠️ Camera controller not initialized, cannot capture frame', category: LogCategory.camera);
+      _logger.w(
+        '⚠️ Camera controller not initialized, cannot capture frame',
+        category: LogCategory.camera,
+      );
       return null;
     }
 
     if (_isCaptureInProgress) {
-      _logger.w('⚠️ Previous capture still in progress, skipping new capture request', category: LogCategory.camera);
+      _logger.w(
+        '⚠️ Previous capture still in progress, skipping new capture request',
+        category: LogCategory.camera,
+      );
       return null;
     }
-    
-    try {
-      _isCaptureInProgress = true;
-      _logger.d('Acquiring frame from camera...', category: LogCategory.camera);
-      
-      final XFile imageFile = await _cameraController!.takePicture();
-      final imageBytes = await imageFile.readAsBytes();
-      
-      _logger.d('✅ Frame captured: ${imageBytes.length} bytes', category: LogCategory.camera);
-      return imageBytes;
-      
-    } catch (e, stackTrace) {
-      _logger.e('❌ Failed to capture frame', category: LogCategory.camera, error: e, stackTrace: stackTrace);
-      return null;
-    } finally {
-      _isCaptureInProgress = false;
+
+    var attempt = 0;
+    while (attempt < 2) {
+      attempt += 1;
+      try {
+        _isCaptureInProgress = true;
+        _logger.d(
+          'Acquiring frame from camera...',
+          category: LogCategory.camera,
+        );
+
+        final XFile imageFile = await _cameraController!.takePicture();
+        final imageBytes = await imageFile.readAsBytes();
+
+        _logger.d(
+          '✅ Frame captured: ${imageBytes.length} bytes',
+          category: LogCategory.camera,
+        );
+        return imageBytes;
+      } on CameraException catch (cameraError, stackTrace) {
+        _logger.e(
+          '❌ Failed to capture frame',
+          category: LogCategory.camera,
+          error: cameraError,
+          stackTrace: stackTrace,
+        );
+
+        final bool canRetry =
+            attempt == 1 && await _handleCameraException(cameraError);
+        if (canRetry) {
+          _logger.i(
+            '🔁 Retrying capture after camera reconfiguration',
+            category: LogCategory.camera,
+          );
+          continue;
+        }
+
+        return null;
+      } catch (e, stackTrace) {
+        _logger.e(
+          '❌ Failed to capture frame',
+          category: LogCategory.camera,
+          error: e,
+          stackTrace: stackTrace,
+        );
+        return null;
+      } finally {
+        _isCaptureInProgress = false;
+      }
     }
+
+    return null;
   }
-  
+
   /// Start periodic frame capture every 5 seconds
   void _startPeriodicCapture() {
-    _logger.i('⏰ Starting periodic frame capture (5 seconds interval)', category: LogCategory.camera);
-    _periodicCaptureTimer = Timer.periodic(const Duration(seconds: 5), (timer) async {
+    _logger.i(
+      '⏰ Starting periodic frame capture (5 seconds interval)',
+      category: LogCategory.camera,
+    );
+    _periodicCaptureTimer = Timer.periodic(const Duration(seconds: 5), (
+      timer,
+    ) async {
       final frame = await captureFrame();
       if (frame != null) {
         _frameStreamController.add(frame);
-        _logger.d('📷 Frame added to stream: ${frame.length} bytes', category: LogCategory.camera);
+        _logger.d(
+          '📷 Frame added to stream: ${frame.length} bytes',
+          category: LogCategory.camera,
+        );
       }
     });
   }
-  
+
   /// Stop periodic frame capture
   void _stopPeriodicCapture() {
-    _logger.i('⏰ Stopping periodic frame capture', category: LogCategory.camera);
+    _logger.i(
+      '⏰ Stopping periodic frame capture',
+      category: LogCategory.camera,
+    );
     _periodicCaptureTimer?.cancel();
     _periodicCaptureTimer = null;
   }
-  
+
   /// Stream of captured frames
   Stream<List<int>> get frameStream => _frameStreamController.stream;
-  
+
   /// Check if camera is available and ready
   bool get isReady => _isInitialized && _isCameraStarted;
-  
+
   /// Dispose of camera resources
   void dispose() {
     _logger.i('🧹 Disposing CameraService...', category: LogCategory.camera);
-    _logger.d('Current state - Initialized: $_isInitialized, Started: $_isCameraStarted', category: LogCategory.camera);
+    _logger.d(
+      'Current state - Initialized: $_isInitialized, Started: $_isCameraStarted',
+      category: LogCategory.camera,
+    );
     _stopPeriodicCapture();
     _frameStreamController.close();
     _cameraController?.dispose();
     _isInitialized = false;
     _isCameraStarted = false;
-    _logger.i('✅ CameraService disposed successfully', category: LogCategory.camera);
+    _logger.i(
+      '✅ CameraService disposed successfully',
+      category: LogCategory.camera,
+    );
   }
 
   Future<void> _ensureCameraPermission() async {
-    _logger.d('Requesting camera permission if needed...', category: LogCategory.camera);
+    _logger.d(
+      'Requesting camera permission if needed...',
+      category: LogCategory.camera,
+    );
     var status = await Permission.camera.status;
     if (!status.isGranted) {
       status = await Permission.camera.request();
     }
 
     if (!status.isGranted) {
-      _logger.e('⚠️ Camera permission denied. Cannot initialize camera.', category: LogCategory.camera);
-      throw CameraException('CameraAccessDenied', 'Camera access permission was denied.');
+      _logger.e(
+        '⚠️ Camera permission denied. Cannot initialize camera.',
+        category: LogCategory.camera,
+      );
+      throw CameraException(
+        'CameraAccessDenied',
+        'Camera access permission was denied.',
+      );
     }
   }
-} 
+
+  Future<void> _initializeCameraController(
+    CameraDescription cameraDescription, {
+    int startIndex = 0,
+  }) async {
+    CameraException? lastError;
+    for (var index = startIndex; index < _resolutionFallbacks.length; index++) {
+      final preset = _resolutionFallbacks[index];
+      _logger.d(
+        'Attempting camera initialization with preset: $preset',
+        category: LogCategory.camera,
+      );
+      final controller = CameraController(
+        cameraDescription,
+        preset,
+        enableAudio: false,
+        imageFormatGroup: ImageFormatGroup.yuv420,
+      );
+
+      try {
+        await controller.initialize();
+        await _cameraController?.dispose();
+        _cameraController = controller;
+        _resolutionIndex = index;
+        _logger.i(
+          '✅ Camera initialized with preset: $preset',
+          category: LogCategory.camera,
+        );
+        return;
+      } on CameraException catch (error, stackTrace) {
+        lastError = error;
+        _logger.w(
+          '⚠️ Failed to initialize camera with preset $preset',
+          category: LogCategory.camera,
+          error: error,
+          stackTrace: stackTrace,
+        );
+        await controller.dispose();
+      }
+    }
+
+    throw lastError ??
+        CameraException(
+          'CameraInitializationFailed',
+          'Unable to initialize camera controller',
+        );
+  }
+
+  Future<bool> _handleCameraException(CameraException cameraError) async {
+    if (_cameraController == null) {
+      return false;
+    }
+
+    final message = cameraError.description?.toLowerCase() ??
+        cameraError.toString().toLowerCase();
+    if (message.contains('no supported surface combination')) {
+      _logger.w(
+        '⚙️ Camera reported unsupported surface combination. Attempting resolution fallback.',
+        category: LogCategory.camera,
+        error: cameraError,
+      );
+      return await _attemptResolutionFallback();
+    }
+
+    return false;
+  }
+
+  Future<bool> _attemptResolutionFallback() async {
+    if (_cameras == null || _cameras!.isEmpty) {
+      return false;
+    }
+
+    if (_resolutionIndex >= _resolutionFallbacks.length - 1) {
+      _logger.w(
+        '⚠️ No further resolution fallbacks available for camera',
+        category: LogCategory.camera,
+      );
+      return false;
+    }
+
+    final nextIndex = _resolutionIndex + 1;
+    final nextPreset = _resolutionFallbacks[nextIndex];
+    _logger.i(
+      '🔄 Reinitializing camera with fallback preset: $nextPreset',
+      category: LogCategory.camera,
+    );
+
+    try {
+      final currentDescription =
+          _cameraController?.description ?? _cameras!.first;
+      await _initializeCameraController(
+        currentDescription,
+        startIndex: nextIndex,
+      );
+      _logger.i(
+        '✅ Camera reinitialized with preset: $nextPreset',
+        category: LogCategory.camera,
+      );
+      return true;
+    } catch (e, stackTrace) {
+      _logger.e(
+        '❌ Failed to reinitialize camera with fallback preset: $nextPreset',
+        category: LogCategory.camera,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return false;
+    }
+  }
+}

--- a/lib/core/services/whisper_service_impl.dart
+++ b/lib/core/services/whisper_service_impl.dart
@@ -13,7 +13,8 @@ import 'app_logger.dart';
 import 'model_download_manager.dart';
 
 // Only import whisper_ggml on non-web platforms
-import 'package:whisper_ggml/whisper_ggml.dart' if (dart.library.html) 'whisper_ggml_web_stub.dart';
+import 'package:whisper_ggml/whisper_ggml.dart'
+    if (dart.library.html) 'whisper_ggml_web_stub.dart';
 
 /// Event class for Whisper STT progress and status
 class WhisperSTTEvent {
@@ -33,87 +34,114 @@ class WhisperSTTEvent {
 /// Service for handling Whisper GGML speech-to-text processing
 class WhisperService {
   static final AppLogger _logger = AppLogger.instance;
-  
+
   bool _isInitialized = false;
   bool _isProcessing = false;
   SpeechConfig _config = const SpeechConfig();
-  
+
   // Whisper GGML instance
   Whisper? _whisper;
   String? _modelPath;
-  static const int _maxQueueSize = 2;
+  static const int _maxQueueSize = 6;
   final Queue<_PendingWhisperRequest> _pendingRequests = Queue();
   bool _isQueueDraining = false;
-  
+  DateTime? _lastQueueDropWarningAt;
+
   // Model download manager
   final ModelDownloadManager _modelDownloadManager;
-  
+
   final StreamController<SpeechResult> _speechResultController =
       StreamController<SpeechResult>.broadcast();
-  
+
   // New: STT progress event stream for AR session integration
   final StreamController<WhisperSTTEvent> _sttEventController =
       StreamController<WhisperSTTEvent>.broadcast();
-  
+
   Stream<SpeechResult> get speechResults => _speechResultController.stream;
-  
+
   // New: Expose STT events stream
   Stream<WhisperSTTEvent> get sttEvents => _sttEventController.stream;
-  
+
   bool get isInitialized => _isInitialized;
   bool get isProcessing => _isProcessing;
-  
-  WhisperService({ModelDownloadManager? modelDownloadManager}) 
+
+  WhisperService({ModelDownloadManager? modelDownloadManager})
       : _modelDownloadManager = modelDownloadManager ?? ModelDownloadManager();
-  
+
   /// Initialize the Whisper service with configuration
   Future<bool> initialize({SpeechConfig? config}) async {
     if (_isInitialized) return true;
-    
+
     // Check if we're on web platform
     if (kIsWeb) {
-      _logger.w('⚠️ Web platform detected - Whisper service not available', category: LogCategory.speech);
-      _logger.w('⚠️ Using fallback mode for web builds', category: LogCategory.speech);
+      _logger.w(
+        '⚠️ Web platform detected - Whisper service not available',
+        category: LogCategory.speech,
+      );
+      _logger.w(
+        '⚠️ Using fallback mode for web builds',
+        category: LogCategory.speech,
+      );
       _isInitialized = true;
       return true;
     }
-    
+
     try {
       _config = config ?? const SpeechConfig();
-      _logger.i('🔧 Initializing Whisper service with model: ${_config.whisperModel}', category: LogCategory.speech);
-      
+      _logger.i(
+        '🔧 Initializing Whisper service with model: ${_config.whisperModel}',
+        category: LogCategory.speech,
+      );
+
       // Emit STT event for initialization start
-      _sttEventController.add(const WhisperSTTEvent(
-        progress: 0.0,
-        message: 'Initializing Whisper service...',
-      ));
-      
+      _sttEventController.add(
+        const WhisperSTTEvent(
+          progress: 0.0,
+          message: 'Initializing Whisper service...',
+        ),
+      );
+
       // Determine the model key based on the config
       final modelKey = 'whisper-${_config.whisperModel}';
-      _logger.i('🔍 Looking for model: $modelKey', category: LogCategory.speech);
-      
+      _logger.i(
+        '🔍 Looking for model: $modelKey',
+        category: LogCategory.speech,
+      );
+
       // Emit STT event for model checking
-      _sttEventController.add(WhisperSTTEvent(
-        progress: 0.2,
-        message: 'Checking model availability...',
-      ));
-      
+      _sttEventController.add(
+        WhisperSTTEvent(
+          progress: 0.2,
+          message: 'Checking model availability...',
+        ),
+      );
+
       // Check if model exists and is complete
       final modelExists = await _modelDownloadManager.modelExists(modelKey);
-      final modelComplete = await _modelDownloadManager.modelIsComplete(modelKey);
-      
+      final modelComplete = await _modelDownloadManager.modelIsComplete(
+        modelKey,
+      );
+
       if (!modelExists || !modelComplete) {
-        _logger.i('📥 Model not found or incomplete, downloading: $modelKey', category: LogCategory.speech);
-        
+        _logger.i(
+          '📥 Model not found or incomplete, downloading: $modelKey',
+          category: LogCategory.speech,
+        );
+
         // Emit STT event for model download start
-        _sttEventController.add(WhisperSTTEvent(
-          progress: 0.3,
-          message: 'Downloading Whisper model...',
-        ));
-        
+        _sttEventController.add(
+          WhisperSTTEvent(
+            progress: 0.3,
+            message: 'Downloading Whisper model...',
+          ),
+        );
+
         // Check if model is currently downloading
         if (_modelDownloadManager.isDownloading(modelKey)) {
-          _logger.i('⏳ Model is already downloading, waiting...', category: LogCategory.speech);
+          _logger.i(
+            '⏳ Model is already downloading, waiting...',
+            category: LogCategory.speech,
+          );
           // Wait for download to complete
           while (_modelDownloadManager.isDownloading(modelKey)) {
             await Future.delayed(const Duration(seconds: 1));
@@ -122,47 +150,56 @@ class WhisperService {
           // Start download
           await _modelDownloadManager.downloadModel(modelKey);
         }
-        
+
         // Check if download was successful
         if (!await _modelDownloadManager.modelIsComplete(modelKey)) {
           final error = _modelDownloadManager.getError(modelKey);
-          _logger.e('❌ Failed to download model: $error', category: LogCategory.speech);
-          
+          _logger.e(
+            '❌ Failed to download model: $error',
+            category: LogCategory.speech,
+          );
+
           // Emit STT event for model download failure
-          _sttEventController.add(WhisperSTTEvent(
-            progress: 0.0,
-            message: 'Failed to download model: $error',
-            error: error,
-          ));
-          
+          _sttEventController.add(
+            WhisperSTTEvent(
+              progress: 0.0,
+              message: 'Failed to download model: $error',
+              error: error,
+            ),
+          );
+
           throw Exception('Failed to download model: $error');
         }
-        
+
         // Emit STT event for model download complete
-        _sttEventController.add(WhisperSTTEvent(
-          progress: 0.8,
-          message: 'Model download complete',
-        ));
+        _sttEventController.add(
+          WhisperSTTEvent(progress: 0.8, message: 'Model download complete'),
+        );
       }
-      
+
       // Get the model path
       final modelPath = await _modelDownloadManager.getModelPath(modelKey);
       final modelDir = Directory(modelPath).parent.path;
       _modelPath = modelPath;
-      
-      _logger.i('📁 Using model from: $modelPath', category: LogCategory.speech);
+
+      _logger.i(
+        '📁 Using model from: $modelPath',
+        category: LogCategory.speech,
+      );
       _logger.i('📁 Model directory: $modelDir', category: LogCategory.speech);
-      
+
       // Check if the expected model file exists
       final expectedModelFile = File('$modelDir/ggml-base.bin');
-      _logger.i('📁 Expected model file exists: ${await expectedModelFile.exists()}', category: LogCategory.speech);
-      
+      _logger.i(
+        '📁 Expected model file exists: ${await expectedModelFile.exists()}',
+        category: LogCategory.speech,
+      );
+
       // Emit STT event for model loading
-      _sttEventController.add(WhisperSTTEvent(
-        progress: 0.9,
-        message: 'Loading Whisper model...',
-      ));
-      
+      _sttEventController.add(
+        WhisperSTTEvent(progress: 0.9, message: 'Loading Whisper model...'),
+      );
+
       // Initialize Whisper with the specified model
       try {
         _whisper = Whisper(
@@ -172,98 +209,131 @@ class WhisperService {
           ),
           modelDir: modelDir,
         );
-        
+
         // Test the connection by getting version
         final version = await _whisper!.getVersion();
         _logger.i('📋 Whisper version: $version', category: LogCategory.speech);
       } catch (nativeError) {
-        _logger.e('❌ Native Whisper GGML initialization failed: $nativeError', category: LogCategory.speech);
-        _logger.w('⚠️ Whisper service will run in fallback mode', category: LogCategory.speech);
-        
+        _logger.e(
+          '❌ Native Whisper GGML initialization failed: $nativeError',
+          category: LogCategory.speech,
+        );
+        _logger.w(
+          '⚠️ Whisper service will run in fallback mode',
+          category: LogCategory.speech,
+        );
+
         // Set whisper to null but keep _isInitialized as true for fallback mode
         _whisper = null;
         _isInitialized = true;
-        
+
         // Emit STT event for fallback mode
-        _sttEventController.add(const WhisperSTTEvent(
-          progress: 1.0,
-          message: 'Whisper service ready (fallback mode)',
-          isComplete: true,
-        ));
-        
+        _sttEventController.add(
+          const WhisperSTTEvent(
+            progress: 1.0,
+            message: 'Whisper service ready (fallback mode)',
+            isComplete: true,
+          ),
+        );
+
         return true;
       }
-      
+
       _isInitialized = true;
-      _logger.i('✅ Whisper service initialized successfully', category: LogCategory.speech);
-      
+      _logger.i(
+        '✅ Whisper service initialized successfully',
+        category: LogCategory.speech,
+      );
+
       // Emit STT event for initialization complete
-      _sttEventController.add(const WhisperSTTEvent(
-        progress: 1.0,
-        message: 'Whisper service ready',
-        isComplete: true,
-      ));
-      
+      _sttEventController.add(
+        const WhisperSTTEvent(
+          progress: 1.0,
+          message: 'Whisper service ready',
+          isComplete: true,
+        ),
+      );
+
       return true;
     } catch (e, stackTrace) {
-      _logger.e('❌ Failed to initialize Whisper service', category: LogCategory.speech, error: e, stackTrace: stackTrace);
-      
-      // Emit STT event for initialization failure
-      _sttEventController.add(WhisperSTTEvent(
-        progress: 0.0,
-        message: 'Failed to initialize Whisper service',
+      _logger.e(
+        '❌ Failed to initialize Whisper service',
+        category: LogCategory.speech,
         error: e,
-      ));
-      
+        stackTrace: stackTrace,
+      );
+
+      // Emit STT event for initialization failure
+      _sttEventController.add(
+        WhisperSTTEvent(
+          progress: 0.0,
+          message: 'Failed to initialize Whisper service',
+          error: e,
+        ),
+      );
+
       return false;
+    }
   }
-  }
-  
+
   /// Start processing audio data
   Future<bool> startProcessing() async {
     if (!_isInitialized) {
-      _logger.w('⚠️ Whisper service not initialized', category: LogCategory.speech);
+      _logger.w(
+        '⚠️ Whisper service not initialized',
+        category: LogCategory.speech,
+      );
       return false;
     }
-    
+
     if (_isProcessing) {
       _logger.i('🔄 Whisper already processing', category: LogCategory.speech);
       return true;
     }
-    
+
     try {
       _isProcessing = true;
       _logger.i('🎤 Starting Whisper processing', category: LogCategory.speech);
-      
+
       // Emit STT event for processing start
-      _sttEventController.add(const WhisperSTTEvent(
-        progress: 0.0,
-        message: 'Starting on-device STT...',
-      ));
-      
+      _sttEventController.add(
+        const WhisperSTTEvent(
+          progress: 0.0,
+          message: 'Starting on-device STT...',
+        ),
+      );
+
       return true;
     } catch (e, stackTrace) {
-      _logger.e('❌ Failed to start Whisper processing', category: LogCategory.speech, error: e, stackTrace: stackTrace);
-      _isProcessing = false;
-      
-      // Emit STT event for processing start failure
-      _sttEventController.add(WhisperSTTEvent(
-        progress: 0.0,
-        message: 'Failed to start STT processing',
+      _logger.e(
+        '❌ Failed to start Whisper processing',
+        category: LogCategory.speech,
         error: e,
-      ));
-      
+        stackTrace: stackTrace,
+      );
+      _isProcessing = false;
+
+      // Emit STT event for processing start failure
+      _sttEventController.add(
+        WhisperSTTEvent(
+          progress: 0.0,
+          message: 'Failed to start STT processing',
+          error: e,
+        ),
+      );
+
       return false;
     }
   }
-  
+
   /// Core audio processing pipeline (single threaded)
-  Future<SpeechResult> _processAudioBufferInternal(
-    Uint8List audioData,
-  ) async {
+  Future<SpeechResult> _processAudioBufferInternal(Uint8List audioData) async {
     // Handle web platform
     if (kIsWeb) {
-      _logger.w('⚠️ Web platform detected - returning demo result', category: LogCategory.speech);
+      _logger.w(
+        '⚠️ Web platform detected - returning demo result',
+        category: LogCategory.speech,
+      );
       return SpeechResult(
         text: 'Web Demo: Audio processing not available',
         confidence: 0.0,
@@ -271,17 +341,22 @@ class WhisperService {
         timestamp: DateTime.now(),
       );
     }
-    
+
     if (!_isInitialized) {
-      _logger.w('⚠️ Whisper not initialized, returning fallback result', category: LogCategory.speech);
-      
+      _logger.w(
+        '⚠️ Whisper not initialized, returning fallback result',
+        category: LogCategory.speech,
+      );
+
       // Emit STT event for processing failure
-      _sttEventController.add(const WhisperSTTEvent(
-        progress: 0.0,
-        message: 'Whisper not initialized',
-        error: 'Service not initialized',
-      ));
-      
+      _sttEventController.add(
+        const WhisperSTTEvent(
+          progress: 0.0,
+          message: 'Whisper not initialized',
+          error: 'Service not initialized',
+        ),
+      );
+
       return SpeechResult(
         text: "Whisper not initialized",
         confidence: 0.0,
@@ -289,17 +364,22 @@ class WhisperService {
         timestamp: DateTime.now(),
       );
     }
-    
+
     // If Whisper GGML native library failed to load, provide a fallback
     if (_whisper == null) {
-      _logger.w('⚠️ Whisper GGML native library not available, using fallback', category: LogCategory.speech);
-      
+      _logger.w(
+        '⚠️ Whisper GGML native library not available, using fallback',
+        category: LogCategory.speech,
+      );
+
       // Emit STT event for fallback processing
-      _sttEventController.add(const WhisperSTTEvent(
-        progress: 0.5,
-        message: 'Processing with fallback STT...',
-      ));
-      
+      _sttEventController.add(
+        const WhisperSTTEvent(
+          progress: 0.5,
+          message: 'Processing with fallback STT...',
+        ),
+      );
+
       // Simple fallback: return placeholder text based on audio length
       final String fallbackText;
       if (audioData.length < 1000) {
@@ -309,40 +389,47 @@ class WhisperService {
       } else {
         fallbackText = "[Long speech detected - STT unavailable]";
       }
-      
+
       final fallbackResult = SpeechResult(
         text: fallbackText,
         confidence: 0.3,
         isFinal: true,
         timestamp: DateTime.now(),
       );
-      
+
       // Emit STT event for fallback complete
-      _sttEventController.add(const WhisperSTTEvent(
-        progress: 1.0,
-        message: 'Fallback STT complete',
-        isComplete: true,
-      ));
-      
+      _sttEventController.add(
+        const WhisperSTTEvent(
+          progress: 1.0,
+          message: 'Fallback STT complete',
+          isComplete: true,
+        ),
+      );
+
       _speechResultController.add(fallbackResult);
       return fallbackResult;
     }
-    
+
     try {
-      _logger.d('🎵 Processing audio buffer (${audioData.length} bytes)', category: LogCategory.speech);
-      
+      _logger.d(
+        '🎵 Processing audio buffer (${audioData.length} bytes)',
+        category: LogCategory.speech,
+      );
+
       // Emit STT event for processing start
-      _sttEventController.add(const WhisperSTTEvent(
-        progress: 0.3,
-        message: 'Transcribing speech...',
-      ));
-      
+      _sttEventController.add(
+        const WhisperSTTEvent(progress: 0.3, message: 'Transcribing speech...'),
+      );
+
       // Ensure temporary directory exists
       final tempDir = await getTemporaryDirectory();
       final whisperDir = Directory('${tempDir.path}/whisper_cache');
       if (!await whisperDir.exists()) {
         await whisperDir.create(recursive: true);
-        _logger.d('📁 Created whisper cache directory: ${whisperDir.path}', category: LogCategory.speech);
+        _logger.d(
+          '📁 Created whisper cache directory: ${whisperDir.path}',
+          category: LogCategory.speech,
+        );
       }
 
       // Convert raw PCM16 data to WAV format
@@ -357,14 +444,19 @@ class WhisperService {
       final timestamp = DateTime.now().millisecondsSinceEpoch;
       final tempFile = File('${whisperDir.path}/whisper_audio_$timestamp.wav');
       await tempFile.writeAsBytes(wavBytes, flush: true);
-      _logger.d('💾 Saved audio to temp file: ${tempFile.path} (${tempFile.lengthSync()} bytes)', category: LogCategory.speech);
-      
+      _logger.d(
+        '💾 Saved audio to temp file: ${tempFile.path} (${tempFile.lengthSync()} bytes)',
+        category: LogCategory.speech,
+      );
+
       // Emit STT event for audio preparation
-      _sttEventController.add(const WhisperSTTEvent(
-        progress: 0.5,
-        message: 'Preparing audio for transcription...',
-      ));
-      
+      _sttEventController.add(
+        const WhisperSTTEvent(
+          progress: 0.5,
+          message: 'Preparing audio for transcription...',
+        ),
+      );
+
       // Create transcription request
       final transcribeRequest = TranscribeRequest(
         audio: tempFile.path,
@@ -375,19 +467,30 @@ class WhisperService {
         isVerbose: false,
         isNoTimestamps: true, // We don't need timestamps for real-time
       );
-      
-      _logger.d('🎤 Sending transcription request to Whisper GGML...', category: LogCategory.speech);
-      
+
+      _logger.d(
+        '🎤 Sending transcription request to Whisper GGML...',
+        category: LogCategory.speech,
+      );
+
       // Emit STT event for transcription start
-      _sttEventController.add(const WhisperSTTEvent(
-        progress: 0.7,
-        message: 'Processing with Whisper GGML...',
-      ));
-      
-      _logger.d('⚙️ Whisper.transcribe starting with audio file: ${tempFile.path}', category: LogCategory.speech);
+      _sttEventController.add(
+        const WhisperSTTEvent(
+          progress: 0.7,
+          message: 'Processing with Whisper GGML...',
+        ),
+      );
+
+      _logger.d(
+        '⚙️ Whisper.transcribe starting with audio file: ${tempFile.path}',
+        category: LogCategory.speech,
+      );
       // Process audio with Whisper GGML
       if (_modelPath == null) {
-        _logger.e('❌ Whisper model path not set before transcription', category: LogCategory.speech);
+        _logger.e(
+          '❌ Whisper model path not set before transcription',
+          category: LogCategory.speech,
+        );
         throw StateError('Whisper model path is not initialized');
       }
 
@@ -395,52 +498,76 @@ class WhisperService {
         transcribeRequest: transcribeRequest,
         modelPath: _modelPath!,
       );
-      _logger.d('✅ Whisper.transcribe completed for: ${tempFile.path}', category: LogCategory.speech);
-      
-      _logger.d('📝 Whisper GGML response received: "${response.text}"', category: LogCategory.speech);
-      
+      _logger.d(
+        '✅ Whisper.transcribe completed for: ${tempFile.path}',
+        category: LogCategory.speech,
+      );
+
+      _logger.d(
+        '📝 Whisper GGML response received: "${response.text}"',
+        category: LogCategory.speech,
+      );
+
       // Clean up temp file
       await tempFile.delete();
-      _logger.d('🗑️ Cleaned up temp audio file: ${tempFile.path}', category: LogCategory.speech);
-      
+      _logger.d(
+        '🗑️ Cleaned up temp audio file: ${tempFile.path}',
+        category: LogCategory.speech,
+      );
+
       final speechResult = SpeechResult(
         text: response.text,
         confidence: 0.8, // Whisper doesn't provide confidence, use default
         isFinal: true,
         timestamp: DateTime.now(),
       );
-      
-      _logger.i('📝 Whisper result: "${speechResult.text}" (confidence: ${speechResult.confidence})', category: LogCategory.speech);
-      
+
+      _logger.i(
+        '📝 Whisper result: "${speechResult.text}" (confidence: ${speechResult.confidence})',
+        category: LogCategory.speech,
+      );
+
       // Emit STT event for processing complete
-      _sttEventController.add(const WhisperSTTEvent(
-        progress: 1.0,
-        message: 'STT complete',
-        isComplete: true,
-      ));
-      
+      _sttEventController.add(
+        const WhisperSTTEvent(
+          progress: 1.0,
+          message: 'STT complete',
+          isComplete: true,
+        ),
+      );
+
       // Emit the result
       _speechResultController.add(speechResult);
-      _logger.d('📤 Emitted speech result to stream', category: LogCategory.speech);
-      
+      _logger.d(
+        '📤 Emitted speech result to stream',
+        category: LogCategory.speech,
+      );
+
       return speechResult;
     } catch (e, stackTrace) {
-      _logger.e('❌ Error processing audio with Whisper', category: LogCategory.speech, error: e, stackTrace: stackTrace);
-      
-      // Emit STT event for processing error
-      _sttEventController.add(WhisperSTTEvent(
-        progress: 0.0,
-        message: 'Error processing audio',
+      _logger.e(
+        '❌ Error processing audio with Whisper',
+        category: LogCategory.speech,
         error: e,
-      ));
-      
+        stackTrace: stackTrace,
+      );
+
+      // Emit STT event for processing error
+      _sttEventController.add(
+        WhisperSTTEvent(
+          progress: 0.0,
+          message: 'Error processing audio',
+          error: e,
+        ),
+      );
+
       final fallbackResult = SpeechResult(
         text: "Error processing audio",
         confidence: 0.0,
         isFinal: true,
         timestamp: DateTime.now(),
       );
-      
+
       _speechResultController.add(fallbackResult);
       return fallbackResult;
     }
@@ -485,39 +612,43 @@ class WhisperService {
           StateError('Dropped due to Whisper queue backpressure'),
         );
       }
-      _logger.w(
-        '?? Whisper queue saturated - dropping oldest pending chunk to keep latency low',
-        category: LogCategory.speech,
-      );
+
+      final now = DateTime.now();
+      final shouldLog = _lastQueueDropWarningAt == null ||
+          now.difference(_lastQueueDropWarningAt!) > const Duration(seconds: 2);
+      if (shouldLog) {
+        _lastQueueDropWarningAt = now;
+        _logger.w(
+          '?? Whisper queue saturated - dropping oldest pending chunk to keep latency low',
+          category: LogCategory.speech,
+        );
+      }
     }
 
     final completer = Completer<SpeechResult>();
     _pendingRequests.add(
-      _PendingWhisperRequest(
-        Uint8List.fromList(audioData),
-        completer,
-      ),
+      _PendingWhisperRequest(Uint8List.fromList(audioData), completer),
     );
     _drainAudioQueue();
     return completer.future;
   }
-  
+
   /// Update configuration
   Future<void> updateConfig(SpeechConfig config) async {
     _config = config;
     _logger.i('⚙️ Updated Whisper configuration', category: LogCategory.speech);
-    
+
     // Reinitialize if already initialized
     if (_isInitialized) {
       await dispose();
       await initialize(config: config);
     }
   }
-  
+
   /// Stop processing
   Future<void> stopProcessing() async {
     if (!_isProcessing) return;
-    
+
     try {
       while (_pendingRequests.isNotEmpty) {
         final pending = _pendingRequests.removeFirst();
@@ -530,14 +661,18 @@ class WhisperService {
       _isQueueDraining = false;
       _isProcessing = false;
       _logger.i('?? Stopped Whisper processing', category: LogCategory.speech);
-      
+
       // Emit STT event for processing stop
-      _sttEventController.add(const WhisperSTTEvent(
-        progress: 0.0,
-        message: 'STT processing stopped',
-      ));
+      _sttEventController.add(
+        const WhisperSTTEvent(progress: 0.0, message: 'STT processing stopped'),
+      );
     } catch (e, stackTrace) {
-      _logger.e('? Error stopping Whisper processing', category: LogCategory.speech, error: e, stackTrace: stackTrace);
+      _logger.e(
+        '? Error stopping Whisper processing',
+        category: LogCategory.speech,
+        error: e,
+        stackTrace: stackTrace,
+      );
     }
   }
 
@@ -551,7 +686,12 @@ class WhisperService {
       _isInitialized = false;
       _logger.i('🗑️ Whisper service disposed', category: LogCategory.speech);
     } catch (e, stackTrace) {
-      _logger.e('❌ Error disposing Whisper service', category: LogCategory.speech, error: e, stackTrace: stackTrace);
+      _logger.e(
+        '❌ Error disposing Whisper service',
+        category: LogCategory.speech,
+        error: e,
+        stackTrace: stackTrace,
+      );
     }
   }
 
@@ -574,10 +714,6 @@ class WhisperService {
           request = _pendingRequests.removeFirst();
         }
 
-        if (request == null) {
-          continue;
-        }
-
         try {
           final result = await _processAudioBufferInternal(request.audioData);
           if (!request.completer.isCompleted) {
@@ -592,6 +728,7 @@ class WhisperService {
       _isQueueDraining = false;
     });
   }
+
   Uint8List _wrapPcmAsWav({
     required Uint8List pcmBytes,
     required int sampleRate,


### PR DESCRIPTION
## Summary
- add resolution fallback handling in the camera service to recover from unsupported surface combinations
- retry frame capture after camera reconfiguration and centralize controller initialization logic
- expand Whisper queue capacity with throttled saturation logging to avoid dropping audio chunks unnecessarily

## Testing
- dart analyze lib/core/services/camera_service.dart lib/core/services/whisper_service_impl.dart

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e8eddb330832c918394d2279cf7fa)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds camera resolution fallback with capture retry and centralizes controller init; expands Whisper queue to 6 with throttled saturation logging.
> 
> - **Camera**:
>   - **Resolution fallback & retry**: Introduces `_resolutionFallbacks`, `_initializeCameraController()`, and `_attemptResolutionFallback()` to reinit on unsupported surface combinations; `captureFrame()` retries once after handling `CameraException`.
>   - **Controller config**: Initializes with `enableAudio: false` and `ImageFormatGroup.yuv420`.
> - **Whisper STT**:
>   - **Queue/backpressure**: Increases `_maxQueueSize` from `2` to `6`; adds throttled warning logging when dropping oldest chunk; minor queue drain simplification.
>   - **Events/logging**: Keeps STT progress events; improves structured logs and error propagation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af4c3df5d0e73e8b2a50cca870eedc26de2764ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->